### PR TITLE
Possible bugfix: redefine object key as a scope

### DIFF
--- a/archieml.js
+++ b/archieml.js
@@ -163,7 +163,7 @@ function load(input) {
         if (array.length > 0) arrayType = typeof array[0] === 'string' ? 'simple' : 'complex';
 
       } else if (scopeType == '{') {
-        scope = keyScope[keyBits[keyBits.length - 1]] = keyScope[keyBits[keyBits.length - 1]] || {};
+        scope = keyScope[keyBits[keyBits.length - 1]] = (typeof keyScope[keyBits[keyBits.length - 1]] === 'object') ? keyScope[keyBits[keyBits.length - 1]] : {};
       }
     }
   }

--- a/test/archieml.js
+++ b/test/archieml.js
@@ -120,6 +120,7 @@
     equal(load('{scope.scope}\nkey:value').scope.scope.key, 'value', 'scopes can be nested using dot-notaion');
     equal(Object.keys(load('{scope}\nkey:value\n{}\n{scope}\nother:value').scope).length, 2, 'scopes can be reopened');
     equal(load('{scope.scope}\nkey:value\n{scope.otherscope}key:value').scope.scope.key, 'value', 'scopes do not overwrite existing values');
+    deepEqual(load('key: value\n{key}\nsubkey: subvalue'), {key: {subkey: 'subvalue'}}, 'key can later be overwriten to become a namespace');
 
     equal(load('{scope}\n{}\nkey:value').key, 'value', '{} resets to the global scope');
     equal(load('{scope}\n{  }\nkey:value').key, 'value', 'ignore spaces inside {}');


### PR DESCRIPTION
From my reading of the spec (please correct me if I'm wrong), keys can be overwritten later in an ArchieML document, even if the overwrite changes the data structure of the value.

For example, consider the following ArchieML document:
```
key: value
{key}
subkey: subvalue
```

Currently this would return the following json:
```
{
    "key": "value"
}
```

I think the expected behavior is this:
```
{
    "key": {
        "subkey": "subvalue"
    }
}
```

From the spec:

> In cases where duplicate keys change the data structure of the output (for example, a key changes from holding a string to being a namespace for a complex object), the latter definition should again take precedence. Parsers should thus override the existing data structure of the output as necessary to accomodate special lines as they come in.

This PR tests and implements this behavior. Again, I'm not completely sure what the expected behavior is, but based on my reading of the spec, I think this is correct.
