### PR TITLE
Add support for Typescript with a definition file

### DIFF
--- a/archieml.d.ts
+++ b/archieml.d.ts
@@ -1,0 +1,10 @@
+declare namespace archieml {
+  interface AmlOptions {
+    comments: boolean;
+  }
+  function load(content: string, opts?: AmlOptions): any;
+}
+
+declare module "archieml" {
+  export = archieml;
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "url" : "http://github.com/newsdev/archieml-js.git"
   },
   "main": "archieml.js",
+  "typings": "./archieml.d.ts",
   "licenses": [
     {
       "type": "Apache-2.0",


### PR DESCRIPTION
This PR allows Typescript users to import the load function from archieml directly into their code, gets rid of the compiler error "error TS2307: Cannot find module 'archieml'" (which can be build-breaking), and also adds type safety for those users. Accepting this pull request and publishing to npm will instantly give Typescript users these benefits without any further work required on your part.

The actual [definition file](./archieml.d.ts) is very simple, taken almost verbatim from the [Typescript Documentation](https://www.typescriptlang.org/docs/handbook/writing-declaration-files.html#global--external-agnostic-libraries).

I would be happy to keep these definition files up-to-date with future versions of archieml if you choose to merge this PR.