### PR TITLE
Fix Google Drive example

### DIFF
--- a/examples/google_drive.js
+++ b/examples/google_drive.js
@@ -11,7 +11,7 @@ var htmlparser = require('htmlparser2');
 var Entities = require('html-entities').AllHtmlEntities;
 
 // Grab google packages and the drive api
-var google = require('googleapis');
+var { google } = require('googleapis');
 var drive = google.drive('v2');
 
 // Set up auth


### PR DESCRIPTION
The instructions don't work at the moment because the `googleapis` package changed the way it's imported. 

After adding curly braces it works for me.

Reference: https://stackoverflow.com/questions/48894909/google-drive-api-fails-because-librarys-google-drive-function-doesnt-exist