### PR TITLE
Implicit Object Nesting

### DIFF
--- a/archieml.js
+++ b/archieml.js
@@ -191,7 +191,7 @@ function load(input, options) {
       };
       
       // Content of nested scopes within a freeform should be stored under "value."
-      const isNestedFreeform = stackScope && stackScope.flags.indexOf('+') > -1 && flags.indexOf('.') > -1;
+      var isNestedFreeform = stackScope && stackScope.flags.indexOf('+') > -1 && flags.indexOf('.') > -1;
 
       if (scopeType == '[') {
         if (isNestedFreeform) parsedScopeKey = 'value'

--- a/archieml.js
+++ b/archieml.js
@@ -182,12 +182,6 @@ function load(input, options) {
         var parsedScopeKey = keyBits[keyBits.length - 1];
       }
 
-      // Content of nested scopes within a freeform should be stored under "value."
-      if (stackScope && stackScope.flags.indexOf('+') > -1 && flags.indexOf('.') > -1) {
-        if (scopeType === '[') parsedScopeKey = 'value';
-        else if (scopeType === '{') scope = scope.value = {};
-      }
-
       var stackScopeItem = {
         array: null,
         arrayType: null,
@@ -195,7 +189,12 @@ function load(input, options) {
         flags: flags,
         scope: scope
       };
+      
+      // Content of nested scopes within a freeform should be stored under "value."
+      const isNestedFreeform = stackScope && stackScope.flags.indexOf('+') > -1 && flags.indexOf('.') > -1;
+
       if (scopeType == '[') {
+        if (isNestedFreeform) parsedScopeKey = 'value'
         stackScopeItem.array = keyScope[parsedScopeKey] = [];
         if (flags.indexOf('+') > -1) stackScopeItem.arrayType = 'freeform';
         if (nesting) {
@@ -207,6 +206,8 @@ function load(input, options) {
 
       } else if (scopeType == '{') {
         if (nesting) {
+          if (isNestedFreeform) scope = scope.value = {};
+          else scope = keyScope[parsedScopeKey] = keyScope = {};
           stack.push(stackScopeItem);
         } else {
           scope = keyScope[parsedScopeKey] = (typeof keyScope[parsedScopeKey] === 'object') ? keyScope[parsedScopeKey] : {};


### PR DESCRIPTION
## Description

Current spec requires dot notation to nest properties in an object:

```
{object}
{object.a}
foo: foo
{object.a.b}
bar: bar
{object.a.b.c}
baz: baz
```

To reduce verbosity, this PR introduces implicit nesting.  Objects declared with a `.` flag will nest inside the object's parent. Just like with [nested arrays](http://archieml.org/#nested-arrays), objects must be closed with empty brackets to move up to a parent scope.

With this change, we can now simplify the above expression to the following:

```
{object}
{.a}
foo: foo
{.b}
bar: bar
{.c}
baz: baz
```

## Preview
[playground](https://reliable-lace-marionberry.glitch.me/)

## Unit Tests
https://github.com/newsdev/archieml.org/pull/42/files
